### PR TITLE
Simple fix for args with dynamic scheduler

### DIFF
--- a/pytest_parallel/utils.py
+++ b/pytest_parallel/utils.py
@@ -64,9 +64,14 @@ def is_master_process(comm, scheduler):
 def spawn_master_process(global_comm):
     if not is_dyn_master_process(global_comm):
         error_codes = []
-        inter_comm = global_comm.Spawn(
-            sys.argv[0], args=sys.argv[1:], maxprocs=1, errcodes=error_codes
-        )
+        if sys.argv[0].endswith(".py"):
+            inter_comm = global_comm.Spawn(
+                sys.executable, args=sys.argv, maxprocs=1, errcodes=error_codes
+            )
+        else:
+            inter_comm = global_comm.Spawn(
+                sys.argv[0], args=sys.argv[1:], maxprocs=1, errcodes=error_codes
+            )
         for error_code in error_codes:
             if error_code != 0:
                 assert 0

--- a/test/test_pytest_parallel.py
+++ b/test/test_pytest_parallel.py
@@ -69,13 +69,17 @@ def run_pytest_parallel_test(test_name, n_workers, scheduler, capfd, suffix=""):
         f.write(captured.out)
     if not ref_match(output_file_name):
         print("err: ", captured.err)
-        print("out: ", captured.out.replace(os.linesep, '\n'))
+        print("out: ", captured.out.replace(os.linesep, "\n"))
     assert ref_match(output_file_name)
     # cmd += f' > {output_file_path}  2> {stderr_file_path}' # redirections. stderr is actually not very useful (since the tests errors are reported in stdout by PyTest)
 
 
-param_scheduler = ["sequential", "static", "dynamic"] if sys.platform != "win32" else ["sequential", "static"]
-    
+param_scheduler = (
+    ["sequential", "static", "dynamic"]
+    if sys.platform != "win32"
+    else ["sequential", "static"]
+)
+
 
 @pytest.mark.parametrize("scheduler", param_scheduler)
 class TestPytestParallel:


### PR DESCRIPTION
Depending on argv[0] the MPI Spawn command is modified.
It should allow for `python -m pytest ...` to work properly