### PR TITLE
Draft: Change default scheduler to dynamic

### DIFF
--- a/pytest_parallel/plugin.py
+++ b/pytest_parallel/plugin.py
@@ -20,7 +20,7 @@ def pytest_addoption(parser):
         '--scheduler',
         dest='scheduler',
         choices=['sequential', 'static', 'dynamic', 'slurm', 'shell'],
-        default='sequential',
+        default='dynamic',
         help='Method used by pytest_parallel to schedule tests',
     )
 


### PR DESCRIPTION
The `dynamic` is the fastest of the "process-reuse" scheduler and seems to be the best default scheduler.

However, it does not work correctly for some environment (some OpenMPI installations, Windows).

To be merged, this PR needs to address these portability issues (e.g. use subprocess instead of MPI_Comm_spawn and re-implement the communications with sockets)